### PR TITLE
Add test for reading good ion files in integration_test.go

### DIFF
--- a/ion/reader_test.go
+++ b/ion/reader_test.go
@@ -1,7 +1,6 @@
 package ion
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -16,49 +15,10 @@ var blacklist = map[string]bool{
 	"../ion-tests/iontestdata/good/utf32.ion":                true,
 	"../ion-tests/iontestdata/good/whitespace.ion":           true,
 	"../ion-tests/iontestdata/good/item1.10n":                true,
-	"../ion-tests/iontestdata/good/typecodes/T7-large.10n" :  true,
+	"../ion-tests/iontestdata/good/typecodes/T7-large.10n":   true,
 }
 
 type drainfunc func(t *testing.T, r Reader, f string)
-
-func TestReadFiles(t *testing.T) {
-	testReadDir(t, "../ion-tests/iontestdata/good", func(t *testing.T, r Reader, f string) {
-		drain(t, r, 0)
-	})
-}
-
-func drain(t *testing.T, r Reader, level int) {
-	for r.Next() {
-		// print(level, r.Type())
-
-		if !r.IsNull() {
-			switch r.Type() {
-			case StructType, ListType, SexpType:
-				if err := r.StepIn(); err != nil {
-					t.Fatal(err)
-				}
-
-				drain(t, r, level+1)
-
-				if err := r.StepOut(); err != nil {
-					t.Fatal(err)
-				}
-			}
-		}
-	}
-
-	if r.Err() != nil {
-		t.Fatal(r.Err())
-	}
-}
-
-func print(level int, obj interface{}) {
-	fmt.Print(" > ")
-	for i := 0; i < level; i++ {
-		fmt.Print("  ")
-	}
-	fmt.Println(obj)
-}
 
 func TestDecodeFiles(t *testing.T) {
 	testReadDir(t, "../ion-tests/iontestdata/good", func(t *testing.T, r Reader, f string) {
@@ -76,20 +36,6 @@ func TestDecodeFiles(t *testing.T) {
 			_ = v
 		}
 	})
-}
-
-var emptyFiles = []string{
-	"ion-tests/iontestdata/good/blank.ion",
-	"ion-tests/iontestdata/good/empty.ion",
-}
-
-func isEmptyFile(f string) bool {
-	for _, s := range emptyFiles {
-		if f == s {
-			return true
-		}
-	}
-	return false
 }
 
 func testReadDir(t *testing.T, path string, d drainfunc) {


### PR DESCRIPTION
- Add test for reading valid Ion files in integration_test file.
- Minor refactor for `null.containerType`.
- Left decode test in reader_test. We can move it once we started working on decoding.
